### PR TITLE
feat: add knockback feedback on wrong picks

### DIFF
--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -495,9 +495,36 @@ export default class Demo extends Phaser.Scene {
 
     // If the player clicks wrong repeatedly, make sure the feedback always replays.
     item.alphaTween.stop();
-    this.resetItemToHome(item);
-    item.wrongTween.stop();
-    item.wrongTween.restart();
+    // Don't snap to home before playing feedback; play it from the CURRENT on-screen position.
+    this.resetItemVisuals(item);
+
+    // Recreate the wrong tween each time so its start/end are based on the current x/angle.
+    // (A persistent tween would keep the old slot coordinates after shuffles.)
+    item.wrongTween?.stop();
+    item.wrongTween?.remove();
+
+    const startX = item.x;
+    const startAngle = item.angle;
+    item.wrongTween = this.tweens.add({
+      targets: item,
+      scaleX: { from: item.baseScaleX, to: item.baseScaleX * 1.18 },
+      scaleY: { from: item.baseScaleY, to: item.baseScaleY * 1.18 },
+      x: { from: startX, to: startX + 12 },
+      angle: { from: startAngle, to: startAngle + 4 },
+      duration: 65,
+      paused: false,
+      yoyo: true,
+      repeat: 2,
+      ease: 'Quad.easeInOut',
+      onStart: () => {
+        item.setTint(0xff6b6b);
+        this.cameras.main.shake(90, 0.0025, true);
+      },
+      onComplete: () => {
+        // Return to the item's CURRENT home slot after feedback.
+        this.resetItemToHome(item);
+      }
+    });
 
     this.time.delayedCall(500, () => {
       this.inputLocked = false;
@@ -512,11 +539,16 @@ export default class Demo extends Phaser.Scene {
 
   resetItemToHome(item: LearnObject) {
     item.moveTween?.stop();
+    this.resetItemVisuals(item);
+    item.setPosition(item.homeX, item.homeY);
+  }
+
+  resetItemVisuals(item: LearnObject) {
+    // Clear feedback state without teleporting the sprite.
     item.clearTint();
     item.setAngle(item.baseAngle);
     item.setAlpha(item.baseAlpha);
     item.setScale(item.baseScaleX, item.baseScaleY);
-    item.setPosition(item.homeX, item.homeY);
   }
 
   updateShufflePace(correct: boolean) {

--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -196,19 +196,29 @@ export default class Demo extends Phaser.Scene {
       });
 
       // Wrong answer feedback: match the "correct" pop style, just smaller + with a brief red tint.
-      // This keeps the motion consistent and kid-friendly.
+      // Add a quick sideways knockback so failure feels crisp without moving the item off its slot.
       item.wrongTween = this.tweens.add({
         targets: item,
         // Force baseline start so it never dips smaller first.
         scaleX: { from: item.baseScaleX, to: item.baseScaleX * 1.18 },
         scaleY: { from: item.baseScaleY, to: item.baseScaleY * 1.18 },
-        duration: 220,
+        x: {
+          from: item.homeX,
+          to: item.homeX + 12
+        },
+        angle: {
+          from: item.baseAngle,
+          to: item.baseAngle + 4
+        },
+        duration: 65,
         paused: true,
         yoyo: true,
+        repeat: 2,
         persist: true,
         ease: 'Quad.easeInOut',
         onStart: () => {
           item.setTint(0xff6b6b);
+          this.cameras.main.shake(90, 0.0025, true);
         },
         onComplete: () => {
           this.resetItemToHome(item);


### PR DESCRIPTION
Summary
- Wrong picks now do a quick sideways knockback + slight tilt + subtle camera shake, in addition to the existing red tint + pop.

Why
- Makes failure feedback feel more immediate/physical without adding HUD clutter.

Notes
- Tween is anchored to the sprite's home slot (homeX/baseAngle) and still calls resetItemToHome() on complete, so it won't fight shuffle movement.
